### PR TITLE
Fix Tag after Rename CLI

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -56,7 +56,7 @@ jobs:
           name: 'codeowners'
           compress: 'true'
           dest: 'dist'
-          package: 'cmd/codeowners'
+          package: 'cmd/codeownerslint'
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
@@ -64,6 +64,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.tag.outputs.upload_url }}
-        asset_path: ./dist/codeowners-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-        asset_name: codeowners-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        asset_path: ./dist/codeownerslint-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+        asset_name: codeownerslint-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
         asset_content_type: application/gzip


### PR DESCRIPTION
### Description
Fix Tag after Rename CLI to codeownerslint

### Check list
- [ ] Are docs fully updated?
- [ ] Are there test cases covering this increment?

### Additional Notes
N/A
